### PR TITLE
Imported FormTypeInterface in FormAware.

### DIFF
--- a/src/Controller/FormAware.php
+++ b/src/Controller/FormAware.php
@@ -5,6 +5,7 @@ namespace Linio\Controller;
 use Symfony\Component\Form\FormFactory;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\Form\FormTypeInterface;
 
 trait FormAware
 {


### PR DESCRIPTION
The missing use statement should fix issues in Scrutinizer because it was unaware of FormTypeInterface.